### PR TITLE
Morph: add catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: item-service
+  description: Express.js service for item management
+  tags:
+    - typescript
+    - backend
+    - template
+    - express
+    - api
+  annotations:
+    github.com/project-slug: audit-log-service
+spec:
+  type: service
+  lifecycle: production
+  owner: user:default/guest
+  system: default/item-management


### PR DESCRIPTION
This PR contains the following modifications:

- AI (gemini/gemini-2.5-flash):
add a simple backstage catalog-info.yaml file, make sure to include metadata.tags and some tags: typescript, backend (or client for frontend), template, add a couple arbitrary ones if you feel like
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)